### PR TITLE
Feature/endpoints crud operations

### DIFF
--- a/src/app/routes/llm.py
+++ b/src/app/routes/llm.py
@@ -1,0 +1,148 @@
+from flask import Blueprint, request, jsonify
+from flask_login import login_required, current_user
+from src.data.models.notes import Note
+from src.data.models.flashcards import Flashcard
+from src.data.db import SessionLocal
+from src.utils.llm_api import generate_flashcards_from_summary, generate_summary_from_note, \
+    check_user_answer_with_llm
+
+llm_bp = Blueprint('llm', __name__, url_prefix='/llm')
+
+@llm_bp.route('/generate-flashcard/<int:note_id>', methods=['POST'])
+@login_required
+def generate_flashcard(note_id):
+    """
+    Generates flashcards from the AI summary of a specified note.
+
+    Args:
+        note_id (int): The ID of the note for which flashcards should be generated.
+
+    This endpoint verifies that the note exists and belongs to the current user,
+    and that an AI summary is available. Existing flashcards for the note are deleted
+    before new ones are generated and stored.
+
+    Returns:
+        JSON with a success message and HTTP status 201 (Created).
+
+    Raises:
+        404 Not Found if the note does not exist, does not belong to the user,
+        or if there is no AI summary available.
+        500 Internal Server Error if flashcard generation or database operations fail.
+    """
+    session = SessionLocal()
+    try:
+        note = session.query(Note).filter(Note.note_id == note_id, Note.user_id == current_user.id).first()
+        if not note:
+            return jsonify({"error": "Note not found"}), 404
+
+        if not note.ai_summary:
+            return jsonify({"error": "No summary available for this note"}), 404
+
+        existing_cards = session.query(Flashcard).filter(Flashcard.note_id == note_id).all()
+        flashcards_data = generate_flashcards_from_summary(note.ai_summary)
+
+        for card in existing_cards:
+            session.delete(card)
+
+        for card in flashcards_data:
+            flashcard = Flashcard(
+                question=card['question'],
+                answer=card['answer'],
+                type='',
+                note_id=note_id,
+                learned=False,
+                last_studied=None,
+                time_reviewed=0
+            )
+            session.add(flashcard)
+
+        session.commit()
+
+        return jsonify({"message": "Flashcards generated successfully"}), 201
+
+    except Exception as error:
+        session.rollback()
+        return jsonify({"error": str(error)}), 500
+
+    finally:
+        session.close()
+
+@llm_bp.route('/generate-summary/<int:note_id>', methods=['POST'])
+@login_required
+def generate_summary(note_id):
+    """
+    Generates an AI summary for the original content of a specified note.
+
+    Args:
+        note_id (int): The ID of the note to summarize.
+
+    This endpoint checks that the note exists, belongs to the current user,
+    and contains original content. The summary is generated via the LLM
+    and saved to the note's `ai_summary` field.
+
+    Returns:
+        JSON containing the generated summary and HTTP status 200 (OK).
+
+    Raises:
+        404 Not Found if the note does not exist or is not owned by the user.
+        400 Bad Request if the original content is missing.
+        500 Internal Server Error if summary generation or database operations fail.
+    """
+    session = SessionLocal()
+    try:
+
+        note = session.query(Note).filter(Note.note_id == note_id, Note.user_id == current_user.id).first()
+        if not note:
+            return jsonify({"error": "Note not found"}), 404
+
+        if not note.original:
+            return jsonify({"error": "Original note content is empty"}), 400
+
+
+        summary = generate_summary_from_note(note.original)
+
+        note.ai_summary = summary
+        session.commit()
+
+        return jsonify({"ai_summary": summary}), 200
+
+    except Exception as error:
+        session.rollback()
+        return jsonify({"error": str(error)}), 500
+
+    finally:
+        session.close()
+
+@llm_bp.route('/check-answer', methods=['POST'])
+@login_required
+def check_answer():
+    """
+    Evaluates a user's answer to a flashcard question using the LLM.
+
+    Expects JSON payload with:
+    - 'question': The original flashcard question.
+    - 'correct_answer': The expected correct answer.
+    - 'user_answer': The user's submitted answer.
+
+    Returns:
+        JSON containing feedback on the user's answer with HTTP status 200 (OK).
+
+    Raises:
+        400 Bad Request if any required fields are missing.
+        500 Internal Server Error if answer evaluation or LLM interaction fails.
+    """
+    data = request.get_json()
+    question = data.get('question')
+    correct_answer = data.get('correct_answer')
+    user_answer = data.get('user_answer')
+
+    if not all([question, correct_answer, user_answer]):
+        return jsonify({"error": "Missing question, correct_answer or user_answer"}), 400
+
+    try:
+        result = check_user_answer_with_llm(question, correct_answer, user_answer)
+
+        return jsonify(result), 200
+
+    except Exception as error:
+        return jsonify({"error": str(error)}), 500

--- a/src/app/routes/note.py
+++ b/src/app/routes/note.py
@@ -1,0 +1,202 @@
+from flask import Blueprint, request, jsonify
+from flask_login import login_required, current_user
+from src.data.models.notes import Note
+from src.data.db import SessionLocal
+
+note_bp = Blueprint('note', __name__, url_prefix='/note')
+
+@note_bp.route('/store-note', methods=['POST'])
+@login_required
+def store_note():
+    """
+    Creates a new note associated with the currently authenticated user.
+
+    This endpoint expects a JSON payload containing 'title' and 'content' fields.
+    Both fields are mandatory, and if either is missing, a 400 Bad Request response will be returned.
+    Upon successful creation, the note is persisted in the database with a link to the current user's ID.
+
+    Returns:
+        A JSON object containing a confirmation message and the unique identifier of the newly created note,
+        along with HTTP status code 201 (Created).
+
+    Raises:
+        400 Bad Request if required fields are missing.
+        500 Internal Server Error if any database operation fails.
+    """
+    data = request.get_json()
+    session = SessionLocal()
+
+    title = data.get('title')
+    content = data.get('content')
+
+    if not title or not content:
+        return jsonify({"error": "Title and content are required"}), 400
+
+    note = Note(
+        title=title,
+        original=content,
+        user_id=current_user.id
+    )
+
+    try:
+        session.add(note)
+        session.commit()
+        return jsonify({'message': 'Note created', 'note_id': note.note_id}), 201
+
+    except Exception as error:
+        session.rollback()
+        return jsonify({"error": str(error)}), 500
+
+    finally:
+        session.close()
+
+@note_bp.route('/get-note/<int:note_id>', methods=['GET'])
+@login_required
+def get_note(note_id):
+    """
+    Retrieves the AI-generated summary of a note by its ID for the authenticated user.
+
+    The endpoint ensures that the requested note belongs to the user making the request,
+    preventing unauthorized access to other users' notes.
+    If the note does not exist or is not owned by the current user, a 404 Not Found error is returned.
+
+    Args:
+        note_id (int): The unique identifier of the note to be retrieved.
+
+    Returns:
+        A JSON object containing the 'ai_summary' field of the note on success with HTTP 200 status.
+
+    Raises:
+        404 Not Found if no matching note is found for the current user.
+        500 Internal Server Error if any unexpected error occurs during processing.
+    """
+
+    session = SessionLocal()
+
+    try:
+        note = session.query(Note).filter(Note.note_id == note_id, Note.user_id == current_user.id).first()
+        if not note:
+            return jsonify({"error": "Note not found"}), 404
+
+        return jsonify({"ai_summary": note.ai_summary, })
+
+    except Exception as error:
+        return jsonify({"error": str(error)}), 500
+    finally:
+        session.close()
+
+@note_bp.route('/get-notes', methods=['GET'])
+@login_required
+def get_notes():
+    """
+    Fetches a list of all notes that belong to the currently authenticated user.
+
+    Each note returned includes its unique identifier and title,
+    providing a summary view suitable for display in a notes list or dashboard.
+
+    Returns:
+        A JSON array of objects, where each object contains 'note_id' and 'title' keys,
+        with an HTTP 200 status indicating successful retrieval.
+
+    Raises:
+        500 Internal Server Error if an unexpected error occurs during database interaction.
+    """
+
+    session = SessionLocal()
+    try:
+        notes = session.query(Note).filter(Note.user_id == current_user.id).all()
+        result = []
+        for note in notes:
+            result.append({
+                "note_id": note.note_id,
+                "title": note.title,
+            })
+        return jsonify(result), 200
+    except Exception as error:
+        return jsonify({"error": str(error)}), 500
+    finally:
+        session.close()
+
+@note_bp.route('/update-note/<int:note_id>', methods=['PUT'])
+@login_required
+def update_note(note_id):
+    """
+    Updates the title and/or content of a note owned by the authenticated user.
+
+    The client must provide the note's ID as a URL parameter.
+    The request body may include 'title' and/or 'content' fields;
+    only provided fields will be updated, allowing partial updates.
+
+    Args:
+        note_id (int): The unique identifier of the note to update.
+
+    Returns:
+        A JSON response confirming successful update with HTTP 200 status.
+
+    Raises:
+        404 Not Found if the note does not exist or is not owned by the current user.
+        500 Internal Server Error if the update operation fails.
+    """
+
+    session = SessionLocal()
+    data = request.get_json()
+
+    title = data.get('title')
+    content = data.get('content')
+
+    try:
+        note = session.query(Note).filter(Note.note_id == note_id, Note.user_id == current_user.id).first()
+        if not note:
+            return jsonify({"error": "Note not found"}), 404
+
+        if title:
+            note.title = title
+        if content:
+            note.original = content
+
+        session.commit()
+        return jsonify({"message": "Note updated successfully"}), 200
+
+    except Exception as error:
+        session.rollback()
+        return jsonify({"error": str(error)}), 500
+    finally:
+        session.close()
+
+@note_bp.route('/delete-note/<int:note_id>', methods=['DELETE'])
+@login_required
+def delete_note(note_id):
+    """
+    Deletes a note identified by its ID, ensuring it belongs to the authenticated user.
+
+    This operation permanently removes the note from the database.
+    If the note is not found or does not belong to the user, a 404 Not Found error is returned.
+
+    Args:
+        note_id (int): The unique identifier of the note to delete.
+
+    Returns:
+        A JSON confirmation message upon successful deletion with HTTP 200 status.
+
+    Raises:
+        404 Not Found if the note cannot be located for the current user.
+        500 Internal Server Error if deletion fails due to database errors.
+    """
+
+    session = SessionLocal()
+    try:
+        note = session.query(Note).filter(Note.note_id == note_id, Note.user_id == current_user.id).first()
+        if not note:
+            return jsonify({"error": "Note not found"}), 404
+
+        session.delete(note)
+        session.commit()
+        return jsonify({"message": "Note deleted successfully"}), 200
+
+    except Exception as error:
+        session.rollback()
+        return jsonify({"error": str(error)}), 500
+    finally:
+        session.close()
+
+

--- a/src/data/models/notes.py
+++ b/src/data/models/notes.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, Text, DateTime, ForeignKey
+from sqlalchemy import Column, Integer, Text, DateTime, ForeignKey, String
 from datetime import datetime, UTC
 
 from sqlalchemy.orm import relationship
@@ -19,6 +19,7 @@ class Note(Base):
     __tablename__ = "notes"
 
     note_id = Column(Integer, primary_key=True, index=True)
+    title = Column(String, nullable=True)
     original = Column(Text, nullable=False)
     ai_summary = Column(Text, nullable=True)
     created_at = Column(DateTime, default=datetime.now(UTC), nullable=False)

--- a/src/data/models/users.py
+++ b/src/data/models/users.py
@@ -1,5 +1,5 @@
 import datetime
-from sqlalchemy import Column, Integer, String, DateTime
+from sqlalchemy import Column, Integer, String, DateTime, Boolean
 from email_validator import validate_email, EmailNotValidError
 from sqlalchemy.orm import relationship
 
@@ -36,6 +36,7 @@ class User(Base):
     username = Column(String, unique=True, nullable=False, index=True)
     email = Column(String, unique=True, nullable=False, index=True)
     password_hash = Column(String, nullable=False)
+    is_admin = Column(Boolean, default=False)
     created_at = Column(DateTime, default=lambda: datetime.datetime.now(datetime.timezone.utc))
 
     notes = relationship("Note", back_populates="user", cascade="all, delete-orphan")

--- a/src/utils/email.py
+++ b/src/utils/email.py
@@ -1,0 +1,27 @@
+import os
+import smtplib
+from email.mime.text import MIMEText
+from dotenv import load_dotenv
+
+load_dotenv()
+
+SMTP_SERVER = os.getenv("SMTP_SERVER")
+SMTP_PORT = int(os.getenv("SMTP_PORT", 587))
+SMTP_USERNAME = os.getenv("SMTP_USERNAME")
+SMTP_PASSWORD = os.getenv("SMTP_PASSWORD")
+FROM_EMAIL = os.getenv("FROM_EMAIL")
+SECRET_KEY = os.getenv("SECRET_KEY")
+
+def send_reset_email(to_email: str, reset_link: str) -> None:
+    subject = "Password Reset Request"
+    body = f"Hello,\n\nTo reset your password, please click the link below:\n{reset_link}\n\nIf you did not request this, ignore this email."
+
+    msg = MIMEText(body)
+    msg["Subject"] = subject
+    msg["From"] = FROM_EMAIL
+    msg["To"] = to_email
+
+    with smtplib.SMTP(SMTP_SERVER, SMTP_PORT) as server:
+        server.starttls()
+        server.login(SMTP_USERNAME, SMTP_PASSWORD)
+        server.sendmail(FROM_EMAIL, to_email, msg.as_string())

--- a/src/utils/llm_api.py
+++ b/src/utils/llm_api.py
@@ -1,0 +1,14 @@
+# Fake functions to simulate LLM API interactions (placeholders for future implementation)
+
+def generate_flashcards_from_summary(ai_summary: str):
+    """Generate flashcards from AI summary (placeholder)."""
+    pass
+
+def generate_summary_from_note(note_content: str):
+    """Generate summary from note content (placeholder)."""
+    pass
+
+def check_user_answer_with_llm(question: str, correct_answer: str, user_answer: str):
+    """Check user answer via LLM (placeholder)."""
+    pass
+

--- a/src/utils/token.py
+++ b/src/utils/token.py
@@ -1,0 +1,21 @@
+import jwt
+from datetime import datetime, timedelta, UTC
+
+SECRET_KEY = "dein_geheimer_schluessel"
+ALGORITHM = "HS256"
+EXPIRATION_MINUTES = 30
+
+def generate_reset_token(user_id: int) -> str:
+    expire = datetime.now(UTC) + timedelta(minutes=EXPIRATION_MINUTES)
+    payload = {"user_id": user_id, "exp": expire}
+    token = jwt.encode(payload, SECRET_KEY, algorithm=ALGORITHM)
+    return token
+
+def verify_reset_token(token: str) -> int | None:
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        return payload.get("user_id")
+    except jwt.ExpiredSignatureError:
+        return None
+    except jwt.InvalidTokenError:
+        return None


### PR DESCRIPTION
This PR includes the implementation of all major backend endpoints for users, notes, and LLM-related features. Key changes:

**LLM Endpoints (llm.py)**
Added endpoints:
generate_flashcard(note_id)
generate_summary(note_id)
check_answer()
All endpoints are protected via login
Introduced llm_api.py utility with placeholder implementations to prevent runtime errors
These will be replaced with real OpenAI API calls in a future update

**Note Endpoints (note.py)**
Implemented full CRUD endpoints:
store_note()
get_note(note_id)
get_notes()
update_note(note_id)
delete_note(note_id)
All note endpoints require user authentication
Extended Note model in notes.py:
Added title field to support display of note titles in UI lists

**User Endpoints (user.py)**
Implemented endpoints:
create_user()
get_user(user_id)
update_user(user_id)
delete_user(user_id)
logout()
list_users() (requires is_admin = True)
fetch_flashcards(user_id)
change_password(user_id)
request_password_reset()
password_reset()
Authenticated access required for all endpoints except:
create_user
request_password_reset
password_reset
Extended User model in users.py:
Added is_admin flag to control access to admin-only endpoints
Added:
email.py and token.py utilities to support password reset functionality via email

Note:
LLM functionality is currently implemented using placeholder logic. These will be completed once the OpenAI API is integrated.