### PR TITLE
feat: Add quiz functionality with endpoints, service layer, and tests

### DIFF
--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -3,6 +3,7 @@ from flask_login import LoginManager
 from flask import Flask, current_app
 
 from src.data.models import User
+from src.app.routes.quiz import quiz_bp
 from src.app.routes.llm import llm_bp
 from src.app.routes.note import note_bp
 from src.app.routes.ping import ping_bp
@@ -65,6 +66,7 @@ def create_app(config_class, log_file='app.log'):
         app.register_blueprint(user_bp)
         app.register_blueprint(llm_bp)
         app.register_blueprint(note_bp)
+        app.register_blueprint(quiz_bp)
 
         logging.basicConfig(
             filename=log_file,

--- a/src/app/routes/quiz.py
+++ b/src/app/routes/quiz.py
@@ -1,0 +1,66 @@
+from flask import Blueprint, jsonify, current_app
+from flask_login import login_required, current_user
+from src.app.services.quiz_service import QuizService
+from src.utils.constants import HttpStatus
+
+quiz_bp = Blueprint("quiz", __name__, url_prefix="/quiz")
+
+@quiz_bp.route("/start/<int:note_id>", methods=["POST"])
+@login_required
+def start_quiz(note_id):
+    """
+    Starts a quiz by returning all flashcards of the note for the current user.
+
+    Args:
+        note_id (int): ID of the note to start quiz for.
+
+    Returns:
+        JSON containing the flashcards for the quiz and HTTP status 200.
+
+    Raises:
+        404 Not Found if no flashcards found or note doesn't belong to user.
+        500 Internal Server Error on unexpected failures.
+    """
+    session = current_app.config['SESSION_LOCAL']()
+    service = QuizService(session)
+
+    try:
+        flashcards = service.get_flashcards_for_quiz(current_user.id, note_id)
+        if not flashcards:
+            return jsonify({"error": "No flashcards found for this note"}), HttpStatus.NOT_FOUND
+        return jsonify({"flashcards": flashcards}), HttpStatus.OK
+    except Exception as error:
+        session.rollback()
+        return jsonify({"error": str(error)}), HttpStatus.INTERNAL_SERVER_ERROR
+    finally:
+        session.close()
+
+@quiz_bp.route("/progress/<int:note_id>", methods=["GET"])
+@login_required
+def get_progress(note_id):
+    """
+    Returns quiz progress for a note by the current user.
+
+    Args:
+        note_id (int): ID of the note to get quiz progress for.
+
+    Returns:
+        JSON containing progress data and HTTP status 200.
+
+    Raises:
+        404 Not Found if progress data is unavailable.
+        500 Internal Server Error on unexpected failures.
+    """
+    session = current_app.config['SESSION_LOCAL']()
+    service = QuizService(session)
+
+    try:
+        progress = service.get_progress(current_user.id, note_id)
+        if progress is None:
+            return jsonify({"error": "Progress data not found"}), HttpStatus.NOT_FOUND
+        return jsonify(progress), HttpStatus.OK
+    except Exception as error:
+        session.rollback()
+        return jsonify({"error": str(error)}), HttpStatus.INTERNAL_SERVER_ERROR
+    finally:
+        session.close()

--- a/src/app/services/quiz_service.py
+++ b/src/app/services/quiz_service.py
@@ -1,0 +1,106 @@
+from sqlalchemy import and_
+
+from src.data.models.quizzes import Quiz
+from src.data.models.flashcards import Flashcard
+from sqlalchemy.orm import Session
+from src.utils.llm_api import check_user_answer_with_llm
+
+class QuizService:
+    def __init__(self, db_session: Session):
+        """
+        Initializes the QuizService with a given database session.
+
+        Args:
+            db_session (Session): SQLAlchemy database session.
+        """
+        self.db = db_session
+
+    def get_flashcards_for_quiz(self, user_id: int, note_id: int):
+        """
+        Retrieves all flashcards for a specific note to build a quiz.
+
+        Args:
+            user_id (int): ID of the current user.
+            note_id (int): ID of the note to fetch flashcards from.
+
+        Returns:
+            list[dict]: A list of flashcards with their card_id, question, and type.
+        """
+        flashcards = (
+            self.db.query(Flashcard)
+            .filter_by(note_id=note_id)
+            .all()
+        )
+        return [{"card_id": fc.card_id, "question": fc.question, "type": fc.type or "text"} for fc in flashcards]
+
+    def submit_answer(self, user_id: int, card_id: int, user_answer: str) -> dict:
+        """
+        Submits a user's answer for a flashcard question and evaluates it using the LLM.
+
+        Args:
+            user_id (int): ID of the current user.
+            card_id (int): ID of the flashcard being answered.
+            user_answer (str): The answer submitted by the user.
+
+        Returns:
+            dict: Feedback from the LLM evaluation on the user's answer.
+
+        Raises:
+            ValueError: If the flashcard is not found.
+        """
+        flashcard = self.db.query(Flashcard).filter_by(card_id=card_id).first()
+        if not flashcard:
+            raise ValueError("Flashcard not found")
+
+        language = flashcard.note.language if flashcard.note else "en"
+
+        feedback = check_user_answer_with_llm(
+            flashcard.question,
+            flashcard.answer,
+            user_answer,
+            language
+        )
+
+        quiz = Quiz(
+            user_id=user_id,
+            card_id=card_id,
+            answer=user_answer,
+            ai_feedback=feedback.get("result", ""),
+            answered=True
+        )
+        self.db.add(quiz)
+        self.db.commit()
+
+        return feedback
+
+    def get_progress(self, user_id: int, note_id: int):
+        """
+        Calculates quiz progress for a user on a given note.
+
+        Args:
+            user_id (int): ID of the current user.
+            note_id (int): ID of the note.
+
+        Returns:
+            dict: Contains total flashcards, answered flashcards, and progress percentage.
+        """
+        total = (
+            self.db.query(Flashcard)
+            .filter_by(note_id=note_id)
+            .count()
+        )
+        answered = (
+            self.db.query(Quiz)
+            .join(Quiz.flashcard)
+            .filter(and_(
+                Quiz.user_id == user_id,
+                Flashcard.note_id == note_id,
+                Quiz.answered.is_(True)
+            ))
+            .count()
+        )
+        return {
+            "total_flashcards": total,
+            "answered_flashcards": answered,
+            "progress_percent": round((answered / total * 100), 2) if total else 0
+        }

--- a/tests/test_quiz.py
+++ b/tests/test_quiz.py
@@ -1,0 +1,100 @@
+import pytest
+from src.data.models.flashcards import Flashcard
+from src.app.services.quiz_service import QuizService
+
+
+@pytest.fixture()
+def create_flashcards(session, create_note):
+    """
+    Creates and inserts multiple flashcards into the test database,
+    associated with the provided test note.
+
+    This fixture is used to simulate a note with flashcards available
+    for quizzing.
+
+    Yields:
+        list[Flashcard]: A list of flashcard ORM instances.
+    """
+    flashcards = [
+        Flashcard(question="What is AI?", answer="Artificial Intelligence", note_id=create_note.note_id),
+        Flashcard(question="Define ML.", answer="Machine Learning", note_id=create_note.note_id),
+        Flashcard(question="What is NLP?", answer="Natural Language Processing", note_id=create_note.note_id),
+    ]
+    session.add_all(flashcards)
+    session.commit()
+    yield flashcards
+    for fc in flashcards:
+        session.delete(fc)
+    session.commit()
+
+
+def test_start_quiz_success(login_auth_client, create_note, create_flashcards):
+    """
+    Tests the /quiz/start/<note_id> endpoint for a valid request.
+
+    Ensures that when a logged-in user starts a quiz for an existing note
+    with flashcards, the correct number of flashcards are returned with the
+    expected structure.
+
+    Args:
+        login_auth_client: Authenticated Flask test client.
+        create_note: A test note associated with the user.
+        create_flashcards: Flashcards tied to the note.
+    """
+    response = login_auth_client.post(f"/quiz/start/{create_note.note_id}")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert "flashcards" in data
+    assert len(data["flashcards"]) == 3
+    assert all("question" in fc and "card_id" in fc for fc in data["flashcards"])
+
+
+def test_start_quiz_not_found(login_auth_client):
+    """
+    Tests the /quiz/start/<note_id> endpoint with an invalid note ID.
+
+    Ensures the system returns a 404 error when the note does not exist
+    or is not accessible by the user.
+
+    Args:
+        login_auth_client: Authenticated Flask test client.
+    """
+    response = login_auth_client.post("/quiz/start/9999")
+    assert response.status_code == 404
+    assert "error" in response.get_json()
+
+
+def test_quiz_progress(login_auth_client, create_note, create_flashcards, session, create_user):
+    """
+    Tests the /quiz/progress/<note_id> endpoint.
+
+    This test checks:
+    1. That initially, no flashcards have been answered and progress is 0%.
+    2. That submitting one answer correctly updates progress to 33.33%.
+
+    Args:
+        login_auth_client: Authenticated Flask test client.
+        create_note: The note the quiz is based on.
+        create_flashcards: The list of flashcards under that note.
+        session: SQLAlchemy session to manually trigger a service call.
+        create_user: The user submitting the answer.
+    """
+    response = login_auth_client.get(f"/quiz/progress/{create_note.note_id}")
+    assert response.status_code == 200
+    progress = response.get_json()
+    assert progress["total_flashcards"] == 3
+    assert progress["answered_flashcards"] == 0
+    assert progress["progress_percent"] == 0.0
+
+    quiz_service = QuizService(session)
+    quiz_service.submit_answer(
+        user_id=create_user.id,
+        card_id=create_flashcards[0].card_id,
+        user_answer="Artificial Intelligence"
+    )
+
+    response = login_auth_client.get(f"/quiz/progress/{create_note.note_id}")
+    assert response.status_code == 200
+    progress = response.get_json()
+    assert progress["answered_flashcards"] == 1
+    assert progress["progress_percent"] == pytest.approx(33.33, 0.1)


### PR DESCRIPTION
- Implemented `quiz.py` blueprint with `/start/<note_id>` and `/progress/<note_id>` endpoints protected by login.

- Developed `QuizService` handling quiz logic: fetching flashcards, submitting answers with LLM evaluation, and calculating quiz progress.

- Added comprehensive pytest tests for quiz endpoints including flashcard fixtures and progress validation.

- Registered `quiz_bp` blueprint in app factory to integrate quiz routes.